### PR TITLE
Add plans stream.

### DIFF
--- a/tap_invoiced/schemas/plans.json
+++ b/tap_invoiced/schemas/plans.json
@@ -7,7 +7,7 @@
     "amount": {
       "type": [
         "null",
-        "integer"
+        "number"
       ]
     },
     "catalog_item": {

--- a/tap_invoiced/schemas/plans.json
+++ b/tap_invoiced/schemas/plans.json
@@ -1,0 +1,105 @@
+{
+  "type": [
+    "null",
+    "object"
+  ],
+  "properties": {
+    "amount": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "catalog_item": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "currency": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "description": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "interval": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "interval_count": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "metadata": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {}
+    },
+    "name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "notes": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "object": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "pricing_mode": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "quantity_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "tiers": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "created_at": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "updated_at": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    }
+  }
+}

--- a/tap_invoiced/schemas/plans.json
+++ b/tap_invoiced/schemas/plans.json
@@ -86,8 +86,9 @@
     "tiers": {
       "type": [
         "null",
-        "string"
-      ]
+        "object"
+      ],
+      "properties": {}
     },
     "created_at": {
       "type": [

--- a/tap_invoiced/sync.py
+++ b/tap_invoiced/sync.py
@@ -9,9 +9,9 @@ STREAM_SDK_OBJECTS = {
     'customers': 'Customer',
     'estimates': 'Estimate',
     'invoices': 'Invoice',
+    'plans': 'Plan',
     'subscriptions': 'Subscription',
     'transactions': 'Transaction',
-    'plans': 'Plan',
 }
 
 

--- a/tap_invoiced/sync.py
+++ b/tap_invoiced/sync.py
@@ -11,6 +11,7 @@ STREAM_SDK_OBJECTS = {
     'invoices': 'Invoice',
     'subscriptions': 'Subscription',
     'transactions': 'Transaction',
+    'plans': 'Plan',
 }
 
 


### PR DESCRIPTION
Need additional source of plans endpoint.

Hypothetically given this has an `updated_at` property the existing tap should work after viewing the new schema?

# Description of change
Adding `plans` stream to tap. Have added schema & updated `sync.py` file to include the new stream.

# Manual QA steps
 - Successful run and output from tap-invoiced fork to target-jsonl.
 - performed catalog output and discovery successful.
 
# Risks
 - `updated_at` is an integer rather than a string timestamp, unsure if the existing tap can support it.
 
# Rollback steps
 - revert this branch


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204121209647802