### PR TITLE
Feat: add `payments` stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ This tap:
 
 - Pulls raw data from [Invoiced](https://invoiced.com)
 - Extracts the following resources:
-  - [Credit Notes](https://invoiced.com/docs/api/#credit-note-object)
-  - [Customers](https://invoiced.com/docs/api/#customer-object)
-  - [Estimates](https://invoiced.com/docs/api/#estimate-object)
-  - [Invoices](https://invoiced.com/docs/api/#invoice-object)
-  - [Plans](https://invoiced.com/docs/api/#plan-object)
-  - [Subscriptions](https://invoiced.com/docs/api/#subscription-object)
-  - [Transactions](https://invoiced.com/docs/api/#transaction-object)
+  - [Credit Notes](https://developer.invoiced.com/api/credit-notes#credit-note-object)
+  - [Customers](https://developer.invoiced.com/api/customers#customer-object)
+  - [Estimates](https://developer.invoiced.com/api/estimates#estimate-object)
+  - [Invoices](https://developer.invoiced.com/api/invoices#invoice-object)
+  - [Payments]((https://developer.invoiced.com/api/payments#payment-object))
+  - [Plans](https://developer.invoiced.com/api/plans#plan-object)
+  - [Subscriptions](https://developer.invoiced.com/api/subscriptions#subscription-object)
+  - [Transactions](https://web.archive.org/web/20160904134609/http://invoiced.com/docs/api/#transactions) (deprecated)
 - Outputs the schema for each resource
 - Incrementally pulls data based on the input state
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     py_modules=["tap_invoiced"],
     install_requires=[
         "singer-python>=5.4.1",
-        "invoiced==0.12.0"
+        "invoiced==1.4.0"
     ],
     entry_points="""
     [console_scripts]

--- a/tap_invoiced/schemas/payments.json
+++ b/tap_invoiced/schemas/payments.json
@@ -1,0 +1,134 @@
+
+{
+  "type": [
+    "null",
+    "object"
+  ],
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "object": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "customer": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "date": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "currency": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "amount": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "balance": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
+    "matched": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "voided": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "method": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ach_sender_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reference": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "source": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "notes": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "charge": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {}
+    },
+    "applied_to": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {}
+      }
+    },
+    "pdf_url": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "created_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    }
+  }
+}

--- a/tap_invoiced/sync.py
+++ b/tap_invoiced/sync.py
@@ -9,6 +9,7 @@ STREAM_SDK_OBJECTS = {
     'customers': 'Customer',
     'estimates': 'Estimate',
     'invoices': 'Invoice',
+    'payments': 'Payment',
     'plans': 'Plan',
     'subscriptions': 'Subscription',
     'transactions': 'Transaction',


### PR DESCRIPTION
# Description of change
- Update invoiced package version to 1.4.0
  - The `Payment` object is not available on 0.12.0 (the currently required version)
  - It's not the latest, but the `Transaction` class has been removed in 2.0.0
- Update README with new links and a comment

# Manual QA steps
- Used the tap to extract and load Invoiced data into a PostgreSQL database (with `target-postgres`)
 
# Risks
 - My account doesn't support some endpoints (subscriptions, plans), so I couldn't test all streams.
 
# Rollback steps
 - Revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
