### PR TITLE
Exclude unauthorized streams in catalog

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,184 @@
+﻿# Instructions for Building a Singer Tap/Target
+
+This document provides guidance for implementing a high-quality Singer Tap (or Target) in compliance with the Singer specification and community best practices. Use it in conjunction with GitHub Copilot or your preferred IDE.
+
+---
+
+## 1. Rate Limiting
+
+- Respect API rate limits (e.g., daily quotas or per-second limits).
+- For short-term rate limits, detect HTTP 429 or similar errors and implement retries with sleep/delay.
+- Use Singer’s built-in rate-limiting utilities where available.
+
+
+## 2. Memory Efficiency
+
+- Minimize RAM usage by streaming data.
+Example: Use generators or iterators instead of loading entire datasets into memory.
+
+
+## 3. Consistent Date Handling
+
+- Use RFC 3339 format (including time zone offset). UTC (Z) is preferred.
+Examples:
+Good: 2017-01-01T00:00:00Z, 2017-01-01T00:00:00-05:00
+Bad: 2017-01-01 00:00:00
+Use pytz for timezone-aware conversions.
+
+
+## 4. Logging & Exception Handling
+
+- Log every API request (URL + parameters), omitting sensitive info (e.g., API keys).
+- Log progress updates (e.g., “Starting stream X”).
+- On API errors, log status code and response body.
+
+For fatal errors:
+- Log at CRITICAL or FATAL level.
+- Exit with non-zero status.
+- Omit stack trace for known, user-triggered conditions.
+- Include full trace for unexpected exceptions.
+- For recoverable errors, implement retries with exponential backoff (e.g., using the backoff library).
+
+
+## 5. Module Structure
+
+- Organize code into a proper Python module (directory with __init__.py), not a single script file.
+
+
+## 6. Schema Management
+
+- For static schemas, store them as .json files in a schemas/ directory—not as inline Python dicts.
+Prefer explicit schemas:
+- Avoid additionalProperties: true or vague typing.
+- Use clear field names and types.
+- Set additionalProperties: false when schemas must be strict.
+- Be cautious when tightening schemas in new versions—it may require a major version bump per semantic versioning.
+
+
+## 7. JSON Schema Guidelines
+
+- All files under schemas/*.json must follow the JSON Schema standard.
+- Any fields named created_time, modified_time, ending in _time or ending in _date must use the date-time format.
+- Any fields look like date-time field, give suggestion to validate the fields should have date-time format.
+- Avoid using additionalProperties at the root level. It's allowed in nested fields only.
+
+Example:
+{
+  "type": "object",
+  "properties": {
+    "created_time": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "last_access_time": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    }
+  }
+}
+
+
+## 8. Validating Bookmarking
+
+We use the singer.bookmarks module to read from and write to the bookmark state file.
+To ensure correctness, always validate the structure of the bookmark state before processing or committing any changes.
+- In abstract.py, we use get_bookmark() and write_bookmark() to manage bookmarks for streams.
+- The write_bookmark() function overrides the one from the singer module to apply custom behavior.
+- Always confirm that the state structure matches the expected format before writing.
+
+Format Example:
+{
+  "bookmarks": {
+    "stream_name": {
+      "replication_key": "2024-01-01T00:00:00Z"
+    }
+  }
+}
+
+
+Optional validation function:
+def is_valid_bookmark_state(state):
+    return isinstance(state, dict) and \
+           "bookmarks" in state and \
+           isinstance(state["bookmarks"], dict)
+
+
+## 9. Code Quality
+
+- Use pylint and aim for zero error-level messages.
+- CI pipelines (e.g., CircleCI) should enforce linting.
+- Fix or explicitly disable warnings when appropriate.
+
+
+## 10. Loop Safety
+
+- **Avoid `while True` loops.** Use explicit conditions instead (e.g., `while has_more_pages`).
+- Every loop must have a clear exit condition that will eventually be satisfied.
+- For pagination loops, ensure there's a termination condition (e.g., no next page, empty results, max iterations).
+- Add safeguards like maximum iteration counts or timeouts for loops that depend on external API responses.
+
+Good example (explicit condition):
+```python
+max_pages = 1000
+current_page = 1
+has_more_pages = True
+
+while has_more_pages and current_page <= max_pages:
+    response = fetch_page(current_page)
+    if not response or not response.get('data'):
+        has_more_pages = False
+        break
+
+    process_data(response['data'])
+
+    next_page = response.get('next_page')
+    if not next_page:
+        has_more_pages = False
+    else:
+        current_page += 1
+```
+
+Bad example (using while True):
+```python
+while True:
+    response = fetch_page()
+    if not response:
+        break  # Avoid this pattern
+    process_data(response)
+```
+
+
+## 11. Record Completeness
+
+- **Never skip records during sync unless absolutely necessary.**
+- If a record encounters an error during transformation or validation, log the error with full context but do not silently skip it.
+- Only skip records if:
+  - They fail schema validation and cannot be processed (log as WARNING or ERROR).
+  - They are explicitly filtered by business logic (e.g., replication key filtering).
+- **Never use `continue` to skip records on errors without logging.**
+
+Good example (log and handle errors):
+```python
+for record in get_records():
+    try:
+        transformed = transformer.transform(record, schema, metadata)
+        write_record(stream_name, transformed)
+        counter.increment()
+    except Exception as e:
+        LOGGER.error(f"Failed to transform record {record.get('id')}: {e}")
+        # Re-raise or handle based on severity
+        raise
+```
+
+Bad example (silently skipping records):
+```python
+for record in get_records():
+    try:
+        transformed = transformer.transform(record, schema, metadata)
+        write_record(stream_name, transformed)
+    except Exception:
+        continue  # Silently skips - BAD!
+```
+
+- For incremental streams, ensure bookmark filtering logic is correct to avoid data loss.
+- If a record must be skipped, document why in the code and log it clearly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
 
+## 1.0.1
+* Add per-stream access checks during discovery; streams returning HTTP 401 or 403 are excluded from the catalog with a warning instead of failing the entire discovery [#12](https://github.com/singer-io/tap-invoiced/pull/12)
+* Added unit tests for `check_stream_access` helper, `_check_stream_access` wrapper, and access-gated `discover_streams()`
+
 ## 1.0.0
 * Upgrade `singer-python` to `6.8.0` [#11](https://github.com/singer-io/tap-invoiced/pull/11)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-invoiced",
-    version="1.0.0",
+    version="1.0.1",
     description="Singer.io tap for extracting data from Invoiced",
     author="Invoiced",
     url="https://invoiced.com",
@@ -14,6 +14,12 @@ setup(
         "invoiced==3.0.0",
         "backoff==2.2.1",
     ],
+    extras_require={
+        'dev': [
+            'pytest',
+            'coverage'
+        ]
+    },
     entry_points="""
     [console_scripts]
     tap-invoiced=tap_invoiced:main

--- a/tap_invoiced/__init__.py
+++ b/tap_invoiced/__init__.py
@@ -12,7 +12,8 @@ LOGGER = singer.get_logger()
 
 def _build_client(config):
     """Build and return an invoiced.Client from the tap config."""
-    is_sandbox = config.get("sandbox") == "true"
+    sandbox = config.get("sandbox", False)
+    is_sandbox = sandbox if isinstance(sandbox, bool) else str(sandbox).lower() == "true"
     return invoiced.Client(config["api_key"], is_sandbox)
 
 

--- a/tap_invoiced/__init__.py
+++ b/tap_invoiced/__init__.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
 import json
 import singer
+import invoiced
 from singer import utils
 from tap_invoiced.discover import discover_streams
 from tap_invoiced.sync import sync_streams
-import sys
 
 REQUIRED_CONFIG_KEYS = ["start_date", "api_key"]
 LOGGER = singer.get_logger()
+
+
+def _build_client(config):
+    """Build and return an invoiced.Client from the tap config."""
+    is_sandbox = config.get("sandbox") == "true"
+    return invoiced.Client(config["api_key"], is_sandbox)
 
 
 @utils.handle_top_exception(LOGGER)
@@ -18,7 +24,8 @@ def main():
 
     # If discover flag was passed, run discovery mode and dump output to stdout
     if args.discover:
-        catalog = discover_streams()
+        client = _build_client(args.config)
+        catalog = discover_streams(client)
         print(json.dumps(catalog, indent=2))
     # Otherwise run in sync mode
     elif args.catalog:

--- a/tap_invoiced/constants.py
+++ b/tap_invoiced/constants.py
@@ -1,0 +1,9 @@
+# Maps Singer stream name to the corresponding invoiced SDK object attribute.
+STREAM_SDK_OBJECTS = {
+    "credit_notes": "CreditNote",
+    "customers": "Customer",
+    "estimates": "Estimate",
+    "invoices": "Invoice",
+    "plans": "Plan",
+    "subscriptions": "Subscription",
+}

--- a/tap_invoiced/discover.py
+++ b/tap_invoiced/discover.py
@@ -4,7 +4,7 @@ import json
 import singer
 from singer import metadata
 
-from tap_invoiced.stream_access import check_stream_access
+from tap_invoiced.stream_access import check_stream_access, InvoicedStreamAccessError
 
 LOGGER = singer.get_logger()
 
@@ -16,14 +16,21 @@ class InvoicedForbiddenError(Exception):
     """Raised when none of the streams are accessible with the given credentials."""
 
 
-def discover_streams(client=None):
+def discover_streams(client):
     raw_schemas = load_schemas()
     streams = []
     excluded_streams = []
 
     for schema_name, schema in raw_schemas.items():
         # Skip streams that the credentials cannot read.
-        if client is not None and not check_stream_access(client, schema_name):
+        try:
+            check_stream_access(client, schema_name)
+        except InvoicedStreamAccessError:
+            LOGGER.warning(
+                "Stream '%s' is not accessible with the provided credentials and "
+                "has been excluded from the catalog.",
+                schema_name,
+            )
             excluded_streams.append(schema_name)
             continue
 
@@ -45,19 +52,9 @@ def discover_streams(client=None):
         streams.append(catalog_entry)
 
     # If all streams are inaccessible, raise an exception.
-    if client is not None and excluded_streams and not streams:
+    if excluded_streams and not streams:
         raise InvoicedForbiddenError(
-            "HTTP-error-code: 403, Error: The credentials do not have read access to any "
-            "of the streams supported by the tap. Data collection cannot proceed due to "
-            "lack of permissions."
-        )
-
-    # Log excluded streams as a single warning.
-    if excluded_streams:
-        LOGGER.warning(
-            "The following stream(s) are not accessible with the provided credentials "
-            "and have been excluded from the catalog: %s",
-            ", ".join(excluded_streams),
+            "The credentials do not have read access to any of the supported streams."
         )
 
     return {'streams': streams}

--- a/tap_invoiced/discover.py
+++ b/tap_invoiced/discover.py
@@ -1,16 +1,69 @@
 import os
 import json
+
+import singer
 from singer import metadata
+from invoiced.errors import ApiError
+
+from tap_invoiced.stream_access import check_stream_access
+
+LOGGER = singer.get_logger()
 
 KEY_PROPERTIES = ["id"]
 REPLICATION_KEY = "updated_at"
 
+STREAM_SDK_OBJECTS = {
+    "credit_notes": "CreditNote",
+    "customers": "Customer",
+    "estimates": "Estimate",
+    "invoices": "Invoice",
+    "plans": "Plan",
+    "subscriptions": "Subscription",
+}
 
-def discover_streams():
+
+class _InvoicedAuthError(Exception):
+    """Raised internally when an API probe returns HTTP 401 or 403."""
+
+
+def _check_stream_access(client, stream_name):
+    """
+    Probe the invoiced endpoint for *stream_name* with a single-record request
+    to verify that the credentials have read access.
+
+    Returns True if accessible, False on HTTP 401/403.
+    Any other exception is re-raised so genuine connectivity problems surface.
+    """
+    sdk_attr = STREAM_SDK_OBJECTS.get(stream_name)
+    if sdk_attr is None:
+        return True
+
+    sdk_object = getattr(client, sdk_attr)
+
+    def _probe():
+        try:
+            sdk_object.list(per_page=1, page=1)
+        except ApiError as exc:
+            if getattr(exc, "http_status", None) in (401, 403):
+                raise _InvoicedAuthError(str(exc)) from exc
+            raise
+
+    return check_stream_access(
+        stream_name,
+        probe_fn=_probe,
+        auth_error_types=_InvoicedAuthError,
+    )
+
+
+def discover_streams(client=None):
     raw_schemas = load_schemas()
     streams = []
 
     for schema_name, schema in raw_schemas.items():
+        # Skip streams that the credentials cannot read.
+        if client is not None and not _check_stream_access(client, schema_name):
+            continue
+
         # populate any metadata and stream's key properties here..
         stream_key_properties = KEY_PROPERTIES
         stream_metadata = get_metadata(schema,

--- a/tap_invoiced/discover.py
+++ b/tap_invoiced/discover.py
@@ -1,56 +1,30 @@
 import os
 import json
 
+import singer
 from singer import metadata
-from invoiced.errors import ApiError
 
 from tap_invoiced.stream_access import check_stream_access
-from tap_invoiced.constants import STREAM_SDK_OBJECTS
+
+LOGGER = singer.get_logger()
 
 KEY_PROPERTIES = ["id"]
 REPLICATION_KEY = "updated_at"
 
 
-class _InvoicedAuthError(Exception):
-    """Raised internally when an API probe returns HTTP 401 or 403."""
-
-
-def _check_stream_access(client, stream_name):
-    """
-    Probe the invoiced endpoint for *stream_name* with a single-record request
-    to verify that the credentials have read access.
-
-    Returns True if accessible, False on HTTP 401/403.
-    Any other exception is re-raised so genuine connectivity problems surface.
-    """
-    sdk_attr = STREAM_SDK_OBJECTS.get(stream_name)
-    if sdk_attr is None:
-        return True
-
-    sdk_object = getattr(client, sdk_attr)
-
-    def _probe():
-        try:
-            sdk_object.list(per_page=1, page=1)
-        except ApiError as exc:
-            if getattr(exc, "http_status", None) in (401, 403):
-                raise _InvoicedAuthError(str(exc)) from exc
-            raise
-
-    return check_stream_access(
-        stream_name,
-        probe_fn=_probe,
-        auth_error_types=_InvoicedAuthError,
-    )
+class InvoicedForbiddenError(Exception):
+    """Raised when none of the streams are accessible with the given credentials."""
 
 
 def discover_streams(client=None):
     raw_schemas = load_schemas()
     streams = []
+    excluded_streams = []
 
     for schema_name, schema in raw_schemas.items():
         # Skip streams that the credentials cannot read.
-        if client is not None and not _check_stream_access(client, schema_name):
+        if client is not None and not check_stream_access(client, schema_name):
+            excluded_streams.append(schema_name)
             continue
 
         # populate any metadata and stream's key properties here..
@@ -69,6 +43,22 @@ def discover_streams(client=None):
             'key_properties': stream_key_properties
         }
         streams.append(catalog_entry)
+
+    # If all streams are inaccessible, raise an exception.
+    if client is not None and excluded_streams and not streams:
+        raise InvoicedForbiddenError(
+            "HTTP-error-code: 403, Error: The credentials do not have read access to any "
+            "of the streams supported by the tap. Data collection cannot proceed due to "
+            "lack of permissions."
+        )
+
+    # Log excluded streams as a single warning.
+    if excluded_streams:
+        LOGGER.warning(
+            "The following stream(s) are not accessible with the provided credentials "
+            "and have been excluded from the catalog: %s",
+            ", ".join(excluded_streams),
+        )
 
     return {'streams': streams}
 

--- a/tap_invoiced/discover.py
+++ b/tap_invoiced/discover.py
@@ -1,25 +1,14 @@
 import os
 import json
 
-import singer
 from singer import metadata
 from invoiced.errors import ApiError
 
 from tap_invoiced.stream_access import check_stream_access
-
-LOGGER = singer.get_logger()
+from tap_invoiced.constants import STREAM_SDK_OBJECTS
 
 KEY_PROPERTIES = ["id"]
 REPLICATION_KEY = "updated_at"
-
-STREAM_SDK_OBJECTS = {
-    "credit_notes": "CreditNote",
-    "customers": "Customer",
-    "estimates": "Estimate",
-    "invoices": "Invoice",
-    "plans": "Plan",
-    "subscriptions": "Subscription",
-}
 
 
 class _InvoicedAuthError(Exception):

--- a/tap_invoiced/stream_access.py
+++ b/tap_invoiced/stream_access.py
@@ -1,0 +1,32 @@
+import singer
+
+LOGGER = singer.get_logger()
+
+
+def check_stream_access(stream_name, probe_fn, auth_error_types, fallback_accessible=False):
+    """
+    Probe a stream endpoint and return True if accessible, False on auth error.
+
+    :param stream_name: Used in log messages.
+    :param probe_fn: Zero-argument callable that performs the API probe.
+    :param auth_error_types: Exception type(s) indicating 401/403 — returns False.
+    :param fallback_accessible: If True, non-auth errors (e.g. unexpected API
+        behaviour on minimal probe params) are treated as auth-OK and return True.
+        If False (default), they are re-raised.
+    """
+    try:
+        probe_fn()
+        LOGGER.info("Stream '%s' is accessible.", stream_name)
+        return True
+    except auth_error_types:
+        LOGGER.warning(
+            "Stream '%s' is not accessible with the provided credentials. "
+            "It will be excluded from the catalog.",
+            stream_name,
+        )
+        return False
+    except Exception:
+        if fallback_accessible:
+            LOGGER.info("Stream '%s' endpoint reachable (auth OK).", stream_name)
+            return True
+        raise

--- a/tap_invoiced/stream_access.py
+++ b/tap_invoiced/stream_access.py
@@ -1,32 +1,26 @@
-import singer
+from invoiced.errors import ApiError
 
-LOGGER = singer.get_logger()
+from tap_invoiced.constants import STREAM_SDK_OBJECTS
 
 
-def check_stream_access(stream_name, probe_fn, auth_error_types, fallback_accessible=False):
+def check_stream_access(client, stream_name):
     """
-    Probe a stream endpoint and return True if accessible, False on auth error.
+    Probe the Invoiced API endpoint for *stream_name* with a minimal request
+    to verify that the credentials have read access.
 
-    :param stream_name: Used in log messages.
-    :param probe_fn: Zero-argument callable that performs the API probe.
-    :param auth_error_types: Exception type(s) indicating 401/403 — returns False.
-    :param fallback_accessible: If True, non-auth errors (e.g. unexpected API
-        behaviour on minimal probe params) are treated as auth-OK and return True.
-        If False (default), they are re-raised.
+    Returns True if accessible, False on HTTP 401/403.
+    Any other API error is re-raised so genuine connectivity problems surface.
     """
-    try:
-        probe_fn()
-        LOGGER.info("Stream '%s' is accessible.", stream_name)
+    sdk_attr = STREAM_SDK_OBJECTS.get(stream_name)
+    if sdk_attr is None:
         return True
-    except auth_error_types:
-        LOGGER.warning(
-            "Stream '%s' is not accessible with the provided credentials. "
-            "It will be excluded from the catalog.",
-            stream_name,
-        )
-        return False
-    except Exception:
-        if fallback_accessible:
-            LOGGER.info("Stream '%s' endpoint reachable (auth OK).", stream_name)
-            return True
+
+    sdk_object = getattr(client, sdk_attr)
+
+    try:
+        sdk_object.list(per_page=1, page=1)
+        return True
+    except ApiError as exc:
+        if getattr(exc, "http_status", None) in (401, 403):
+            return False
         raise

--- a/tap_invoiced/stream_access.py
+++ b/tap_invoiced/stream_access.py
@@ -3,24 +3,28 @@ from invoiced.errors import ApiError
 from tap_invoiced.constants import STREAM_SDK_OBJECTS
 
 
+class InvoicedStreamAccessError(Exception):
+    """Raised when a stream cannot be accessed due to an auth failure (HTTP 401/403)."""
+
+
 def check_stream_access(client, stream_name):
     """
     Probe the Invoiced API endpoint for *stream_name* with a minimal request
     to verify that the credentials have read access.
 
-    Returns True if accessible, False on HTTP 401/403.
+    Returns normally if accessible.
+    Raises InvoicedStreamAccessError on HTTP 401/403.
     Any other API error is re-raised so genuine connectivity problems surface.
     """
     sdk_attr = STREAM_SDK_OBJECTS.get(stream_name)
     if sdk_attr is None:
-        return True
+        return
 
     sdk_object = getattr(client, sdk_attr)
 
     try:
         sdk_object.list(per_page=1, page=1)
-        return True
     except ApiError as exc:
         if getattr(exc, "http_status", None) in (401, 403):
-            return False
+            raise InvoicedStreamAccessError(stream_name) from exc
         raise

--- a/tap_invoiced/sync.py
+++ b/tap_invoiced/sync.py
@@ -6,16 +6,10 @@ import requests
 import backoff
 from invoiced.errors import ApiConnectionError, ApiError, RateLimitError
 
+from tap_invoiced.constants import STREAM_SDK_OBJECTS
+
 LOGGER = singer.get_logger()
 REPLICATION_KEY = "updated_at"
-STREAM_SDK_OBJECTS = {
-    'credit_notes': 'CreditNote',
-    'customers': 'Customer',
-    'estimates': 'Estimate',
-    'invoices': 'Invoice',
-    'plans': 'Plan',
-    'subscriptions': 'Subscription'
-}
 
 def sync_streams(config, state, catalog):
 

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -16,7 +16,7 @@ from tap_invoiced.discover import (
     InvoicedForbiddenError,
 )
 from tap_invoiced.constants import STREAM_SDK_OBJECTS
-from tap_invoiced.stream_access import check_stream_access
+from tap_invoiced.stream_access import check_stream_access, InvoicedStreamAccessError
 
 EXPECTED_STREAMS = {
     "credit_notes",
@@ -31,20 +31,28 @@ EXPECTED_STREAMS = {
 class TestDiscoverStreams(unittest.TestCase):
     """discover_streams() returns a well-formed Singer catalog."""
 
+    def setUp(self):
+        self.mock_client = MagicMock()
+        self.patcher = patch("tap_invoiced.discover.check_stream_access")
+        self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+
     def test_returns_streams_key(self):
         """discover_streams() result contains the 'streams' key."""
-        result = discover_streams()
+        result = discover_streams(self.mock_client)
         self.assertIn("streams", result)
 
     def test_returns_all_six_streams(self):
         """discover_streams() includes all six expected tap_stream_ids."""
-        result = discover_streams()
+        result = discover_streams(self.mock_client)
         stream_ids = {s["tap_stream_id"] for s in result["streams"]}
         self.assertEqual(EXPECTED_STREAMS, stream_ids)
 
     def test_each_entry_has_required_catalog_keys(self):
         """Every stream entry has stream, tap_stream_id, schema, metadata, key_properties."""
-        result = discover_streams()
+        result = discover_streams(self.mock_client)
         required_keys = ("stream", "tap_stream_id", "schema", "metadata", "key_properties")
         for entry in result["streams"]:
             for key in required_keys:
@@ -52,32 +60,32 @@ class TestDiscoverStreams(unittest.TestCase):
 
     def test_stream_name_matches_tap_stream_id(self):
         """stream and tap_stream_id are equal in every catalog entry."""
-        result = discover_streams()
+        result = discover_streams(self.mock_client)
         for entry in result["streams"]:
             self.assertEqual(entry["stream"], entry["tap_stream_id"])
 
     def test_key_properties_is_id_for_all_streams(self):
         """All streams use ['id'] as their key_properties."""
-        result = discover_streams()
+        result = discover_streams(self.mock_client)
         for entry in result["streams"]:
             self.assertEqual(["id"], entry["key_properties"])
 
     def test_each_schema_has_properties(self):
         """Every stream schema includes a non-empty 'properties' object."""
-        result = discover_streams()
+        result = discover_streams(self.mock_client)
         for entry in result["streams"]:
             self.assertIn("properties", entry["schema"])
             self.assertGreater(len(entry["schema"]["properties"]), 0)
 
     def test_metadata_is_list(self):
         """Metadata for every stream is a list (Singer format)."""
-        result = discover_streams()
+        result = discover_streams(self.mock_client)
         for entry in result["streams"]:
             self.assertIsInstance(entry["metadata"], list)
 
     def test_forced_replication_method_is_incremental(self):
         """All streams are set to INCREMENTAL replication via metadata."""
-        result = discover_streams()
+        result = discover_streams(self.mock_client)
         for entry in result["streams"]:
             mdata_map = metadata.to_map(entry["metadata"])
             method = metadata.get(mdata_map, (), "forced-replication-method")
@@ -86,7 +94,7 @@ class TestDiscoverStreams(unittest.TestCase):
 
     def test_valid_replication_key_is_updated_at(self):
         """All streams declare 'updated_at' as their valid replication key."""
-        result = discover_streams()
+        result = discover_streams(self.mock_client)
         for entry in result["streams"]:
             mdata_map = metadata.to_map(entry["metadata"])
             rep_keys = metadata.get(mdata_map, (), "valid-replication-keys")
@@ -95,7 +103,7 @@ class TestDiscoverStreams(unittest.TestCase):
 
     def test_id_field_inclusion_is_automatic(self):
         """The 'id' field is marked as inclusion=automatic in every stream."""
-        result = discover_streams()
+        result = discover_streams(self.mock_client)
         for entry in result["streams"]:
             mdata_map = metadata.to_map(entry["metadata"])
             inclusion = metadata.get(mdata_map, ("properties", "id"), "inclusion")
@@ -104,7 +112,7 @@ class TestDiscoverStreams(unittest.TestCase):
 
     def test_updated_at_field_inclusion_is_automatic(self):
         """The 'updated_at' field is marked as inclusion=automatic in every stream."""
-        result = discover_streams()
+        result = discover_streams(self.mock_client)
         for entry in result["streams"]:
             mdata_map = metadata.to_map(entry["metadata"])
             inclusion = metadata.get(mdata_map, ("properties", "updated_at"), "inclusion")
@@ -263,22 +271,22 @@ class TestCheckStreamAccess(unittest.TestCase):
     def test_returns_true_when_accessible(self):
         client, sdk_obj = self._make_client()
         result = check_stream_access(client, "invoices")
-        self.assertTrue(result)
+        self.assertIsNone(result)
         sdk_obj.list.assert_called_once_with(per_page=1, page=1)
 
-    def test_returns_false_on_403_api_error(self):
+    def test_raises_stream_access_error_on_403(self):
         exc = ApiError()
         exc.http_status = 403
         client, _ = self._make_client(side_effect=exc)
-        result = check_stream_access(client, "customers")
-        self.assertFalse(result)
+        with self.assertRaises(InvoicedStreamAccessError):
+            check_stream_access(client, "customers")
 
-    def test_returns_false_on_401_api_error(self):
+    def test_raises_stream_access_error_on_401(self):
         exc = ApiError()
         exc.http_status = 401
         client, _ = self._make_client(side_effect=exc)
-        result = check_stream_access(client, "invoices")
-        self.assertFalse(result)
+        with self.assertRaises(InvoicedStreamAccessError):
+            check_stream_access(client, "invoices")
 
     def test_reraises_non_auth_api_error(self):
         exc = ApiError()
@@ -287,10 +295,10 @@ class TestCheckStreamAccess(unittest.TestCase):
         with self.assertRaises(ApiError):
             check_stream_access(client, "invoices")
 
-    def test_unknown_stream_returns_true(self):
+    def test_unknown_stream_returns_none(self):
         client, sdk_obj = self._make_client()
         result = check_stream_access(client, "unknown_stream")
-        self.assertTrue(result)
+        self.assertIsNone(result)
         sdk_obj.list.assert_not_called()
 
 
@@ -304,7 +312,7 @@ class TestDiscoverStreamsWithClient(unittest.TestCase):
     @patch("tap_invoiced.discover.check_stream_access")
     def test_all_accessible_all_in_catalog(self, mock_check):
         """All streams accessible → all six appear in the catalog."""
-        mock_check.return_value = True
+        mock_check.return_value = None
         client = MagicMock()
         result = discover_streams(client)
         stream_ids = {s["tap_stream_id"] for s in result["streams"]}
@@ -312,9 +320,12 @@ class TestDiscoverStreamsWithClient(unittest.TestCase):
 
     @patch("tap_invoiced.discover.check_stream_access")
     def test_inaccessible_stream_excluded(self, mock_check):
-        """A stream returning False from access check is excluded from the catalog."""
+        """A stream raising InvoicedStreamAccessError is excluded from the catalog."""
         blocked = "invoices"
-        mock_check.side_effect = lambda client, name: name != blocked
+        def _side_effect(client, name):
+            if name == blocked:
+                raise InvoicedStreamAccessError(name)
+        mock_check.side_effect = _side_effect
         client = MagicMock()
         result = discover_streams(client)
         stream_ids = {s["tap_stream_id"] for s in result["streams"]}
@@ -324,7 +335,7 @@ class TestDiscoverStreamsWithClient(unittest.TestCase):
     @patch("tap_invoiced.discover.check_stream_access")
     def test_all_inaccessible_raises_exception(self, mock_check):
         """All streams inaccessible → raises InvoicedForbiddenError."""
-        mock_check.return_value = False
+        mock_check.side_effect = InvoicedStreamAccessError
         client = MagicMock()
         with self.assertRaises(InvoicedForbiddenError):
             discover_streams(client)
@@ -332,22 +343,10 @@ class TestDiscoverStreamsWithClient(unittest.TestCase):
     @patch("tap_invoiced.discover.check_stream_access")
     def test_check_called_once_per_stream(self, mock_check):
         """check_stream_access is called exactly once per stream."""
-        mock_check.return_value = True
+        mock_check.return_value = None
         client = MagicMock()
         discover_streams(client)
         self.assertEqual(len(EXPECTED_STREAMS), mock_check.call_count)
-
-    def test_no_client_skips_access_check(self):
-        """discover_streams(None) skips access checks and returns all streams."""
-        result = discover_streams(None)
-        stream_ids = {s["tap_stream_id"] for s in result["streams"]}
-        self.assertEqual(EXPECTED_STREAMS, stream_ids)
-
-    def test_no_client_default_arg_skips_access_check(self):
-        """discover_streams() with no argument skips access checks."""
-        result = discover_streams()
-        stream_ids = {s["tap_stream_id"] for s in result["streams"]}
-        self.assertEqual(EXPECTED_STREAMS, stream_ids)
 
 
 if __name__ == "__main__":

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,7 +1,7 @@
 """Unit tests for tap_invoiced.discover module.
 
 Covers: discover_streams(), load_schemas(), get_metadata(), field inclusion rules,
-and stream access-checking logic (check_stream_access / _check_stream_access).
+and stream access-checking logic (check_stream_access).
 """
 import unittest
 from unittest.mock import patch, MagicMock
@@ -13,8 +13,7 @@ from tap_invoiced.discover import (
     discover_streams,
     load_schemas,
     get_metadata,
-    _check_stream_access,
-    _InvoicedAuthError,
+    InvoicedForbiddenError,
 )
 from tap_invoiced.constants import STREAM_SDK_OBJECTS
 from tap_invoiced.stream_access import check_stream_access
@@ -246,60 +245,24 @@ class TestGetMetadata(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# check_stream_access (shared utils helper)
+# check_stream_access (tap_invoiced.stream_access)
 # ---------------------------------------------------------------------------
 
-class TestCheckStreamAccessHelper(unittest.TestCase):
-    """Tests for the reusable check_stream_access helper in tap_invoiced.stream_access."""
-
-    def test_returns_true_when_probe_succeeds(self):
-        result = check_stream_access("invoices", probe_fn=lambda: None, auth_error_types=_InvoicedAuthError)
-        self.assertTrue(result)
-
-    def test_returns_false_on_auth_error(self):
-        def _raise():
-            raise _InvoicedAuthError("403 Forbidden")
-
-        result = check_stream_access("invoices", probe_fn=_raise, auth_error_types=_InvoicedAuthError)
-        self.assertFalse(result)
-
-    def test_reraises_non_auth_error_when_fallback_false(self):
-        def _raise():
-            raise RuntimeError("network error")
-
-        with self.assertRaises(RuntimeError):
-            check_stream_access("invoices", probe_fn=_raise, auth_error_types=_InvoicedAuthError,
-                                fallback_accessible=False)
-
-    def test_returns_true_on_non_auth_error_when_fallback_true(self):
-        def _raise():
-            raise RuntimeError("400 Bad Request")
-
-        result = check_stream_access("invoices", probe_fn=_raise, auth_error_types=_InvoicedAuthError,
-                                     fallback_accessible=True)
-        self.assertTrue(result)
-
-
-# ---------------------------------------------------------------------------
-# _check_stream_access (tap-invoiced-specific wrapper)
-# ---------------------------------------------------------------------------
-
-class TestInvoicedCheckStreamAccess(unittest.TestCase):
-    """Tests for the _check_stream_access wrapper in tap_invoiced.discover."""
+class TestCheckStreamAccess(unittest.TestCase):
+    """Tests for check_stream_access in tap_invoiced.stream_access."""
 
     def _make_client(self, side_effect=None):
         client = MagicMock()
         sdk_obj = MagicMock()
         if side_effect:
             sdk_obj.list.side_effect = side_effect
-        # Make getattr(client, sdk_attr) return the mock sdk_obj
         for attr in STREAM_SDK_OBJECTS.values():
             setattr(client, attr, sdk_obj)
         return client, sdk_obj
 
     def test_returns_true_when_accessible(self):
         client, sdk_obj = self._make_client()
-        result = _check_stream_access(client, "invoices")
+        result = check_stream_access(client, "invoices")
         self.assertTrue(result)
         sdk_obj.list.assert_called_once_with(per_page=1, page=1)
 
@@ -307,14 +270,14 @@ class TestInvoicedCheckStreamAccess(unittest.TestCase):
         exc = ApiError()
         exc.http_status = 403
         client, _ = self._make_client(side_effect=exc)
-        result = _check_stream_access(client, "customers")
+        result = check_stream_access(client, "customers")
         self.assertFalse(result)
 
     def test_returns_false_on_401_api_error(self):
         exc = ApiError()
         exc.http_status = 401
         client, _ = self._make_client(side_effect=exc)
-        result = _check_stream_access(client, "invoices")
+        result = check_stream_access(client, "invoices")
         self.assertFalse(result)
 
     def test_reraises_non_auth_api_error(self):
@@ -322,11 +285,11 @@ class TestInvoicedCheckStreamAccess(unittest.TestCase):
         exc.http_status = 500
         client, _ = self._make_client(side_effect=exc)
         with self.assertRaises(ApiError):
-            _check_stream_access(client, "invoices")
+            check_stream_access(client, "invoices")
 
     def test_unknown_stream_returns_true(self):
         client, sdk_obj = self._make_client()
-        result = _check_stream_access(client, "unknown_stream")
+        result = check_stream_access(client, "unknown_stream")
         self.assertTrue(result)
         sdk_obj.list.assert_not_called()
 
@@ -338,7 +301,7 @@ class TestInvoicedCheckStreamAccess(unittest.TestCase):
 class TestDiscoverStreamsWithClient(unittest.TestCase):
     """Tests for discover_streams() when a client is supplied."""
 
-    @patch("tap_invoiced.discover._check_stream_access")
+    @patch("tap_invoiced.discover.check_stream_access")
     def test_all_accessible_all_in_catalog(self, mock_check):
         """All streams accessible → all six appear in the catalog."""
         mock_check.return_value = True
@@ -347,7 +310,7 @@ class TestDiscoverStreamsWithClient(unittest.TestCase):
         stream_ids = {s["tap_stream_id"] for s in result["streams"]}
         self.assertEqual(EXPECTED_STREAMS, stream_ids)
 
-    @patch("tap_invoiced.discover._check_stream_access")
+    @patch("tap_invoiced.discover.check_stream_access")
     def test_inaccessible_stream_excluded(self, mock_check):
         """A stream returning False from access check is excluded from the catalog."""
         blocked = "invoices"
@@ -358,17 +321,17 @@ class TestDiscoverStreamsWithClient(unittest.TestCase):
         self.assertNotIn(blocked, stream_ids)
         self.assertEqual(EXPECTED_STREAMS - {blocked}, stream_ids)
 
-    @patch("tap_invoiced.discover._check_stream_access")
-    def test_all_inaccessible_returns_empty_catalog(self, mock_check):
-        """All streams inaccessible → empty streams list."""
+    @patch("tap_invoiced.discover.check_stream_access")
+    def test_all_inaccessible_raises_exception(self, mock_check):
+        """All streams inaccessible → raises InvoicedForbiddenError."""
         mock_check.return_value = False
         client = MagicMock()
-        result = discover_streams(client)
-        self.assertEqual([], result["streams"])
+        with self.assertRaises(InvoicedForbiddenError):
+            discover_streams(client)
 
-    @patch("tap_invoiced.discover._check_stream_access")
+    @patch("tap_invoiced.discover.check_stream_access")
     def test_check_called_once_per_stream(self, mock_check):
-        """_check_stream_access is called exactly once per stream."""
+        """check_stream_access is called exactly once per stream."""
         mock_check.return_value = True
         client = MagicMock()
         discover_streams(client)

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,13 +1,23 @@
 """Unit tests for tap_invoiced.discover module.
 
-Covers: discover_streams(), load_schemas(), get_metadata(), field inclusion rules.
+Covers: discover_streams(), load_schemas(), get_metadata(), field inclusion rules,
+and stream access-checking logic (check_stream_access / _check_stream_access).
 """
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 
 from singer import metadata
+from invoiced.errors import ApiError
 
-from tap_invoiced.discover import discover_streams, load_schemas, get_metadata
+from tap_invoiced.discover import (
+    discover_streams,
+    load_schemas,
+    get_metadata,
+    _check_stream_access,
+    _InvoicedAuthError,
+    STREAM_SDK_OBJECTS,
+)
+from tap_invoiced.stream_access import check_stream_access
 
 EXPECTED_STREAMS = {
     "credit_notes",
@@ -233,6 +243,148 @@ class TestGetMetadata(unittest.TestCase):
         mdata = get_metadata(schema, ["id"], "INCREMENTAL", "updated_at")
         mdata_map = metadata.to_map(mdata)
         self.assertEqual("automatic", metadata.get(mdata_map, ("properties", "updated"), "inclusion"))
+
+
+# ---------------------------------------------------------------------------
+# check_stream_access (shared utils helper)
+# ---------------------------------------------------------------------------
+
+class TestCheckStreamAccessHelper(unittest.TestCase):
+    """Tests for the reusable check_stream_access helper in tap_invoiced.utils."""
+
+    def test_returns_true_when_probe_succeeds(self):
+        result = check_stream_access("invoices", probe_fn=lambda: None, auth_error_types=_InvoicedAuthError)
+        self.assertTrue(result)
+
+    def test_returns_false_on_auth_error(self):
+        def _raise():
+            raise _InvoicedAuthError("403 Forbidden")
+
+        result = check_stream_access("invoices", probe_fn=_raise, auth_error_types=_InvoicedAuthError)
+        self.assertFalse(result)
+
+    def test_reraises_non_auth_error_when_fallback_false(self):
+        def _raise():
+            raise RuntimeError("network error")
+
+        with self.assertRaises(RuntimeError):
+            check_stream_access("invoices", probe_fn=_raise, auth_error_types=_InvoicedAuthError,
+                                fallback_accessible=False)
+
+    def test_returns_true_on_non_auth_error_when_fallback_true(self):
+        def _raise():
+            raise RuntimeError("400 Bad Request")
+
+        result = check_stream_access("invoices", probe_fn=_raise, auth_error_types=_InvoicedAuthError,
+                                     fallback_accessible=True)
+        self.assertTrue(result)
+
+
+# ---------------------------------------------------------------------------
+# _check_stream_access (tap-invoiced-specific wrapper)
+# ---------------------------------------------------------------------------
+
+class TestInvoicedCheckStreamAccess(unittest.TestCase):
+    """Tests for the _check_stream_access wrapper in tap_invoiced.discover."""
+
+    def _make_client(self, side_effect=None):
+        client = MagicMock()
+        sdk_obj = MagicMock()
+        if side_effect:
+            sdk_obj.list.side_effect = side_effect
+        # Make getattr(client, sdk_attr) return the mock sdk_obj
+        for attr in STREAM_SDK_OBJECTS.values():
+            setattr(client, attr, sdk_obj)
+        return client, sdk_obj
+
+    def test_returns_true_when_accessible(self):
+        client, sdk_obj = self._make_client()
+        result = _check_stream_access(client, "invoices")
+        self.assertTrue(result)
+        sdk_obj.list.assert_called_once_with(per_page=1, page=1)
+
+    def test_returns_false_on_403_api_error(self):
+        exc = ApiError()
+        exc.http_status = 403
+        client, _ = self._make_client(side_effect=exc)
+        result = _check_stream_access(client, "customers")
+        self.assertFalse(result)
+
+    def test_returns_false_on_401_api_error(self):
+        exc = ApiError()
+        exc.http_status = 401
+        client, _ = self._make_client(side_effect=exc)
+        result = _check_stream_access(client, "invoices")
+        self.assertFalse(result)
+
+    def test_reraises_non_auth_api_error(self):
+        exc = ApiError()
+        exc.http_status = 500
+        client, _ = self._make_client(side_effect=exc)
+        with self.assertRaises(ApiError):
+            _check_stream_access(client, "invoices")
+
+    def test_unknown_stream_returns_true(self):
+        client, sdk_obj = self._make_client()
+        result = _check_stream_access(client, "unknown_stream")
+        self.assertTrue(result)
+        sdk_obj.list.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# discover_streams() with client (access-gated discovery)
+# ---------------------------------------------------------------------------
+
+class TestDiscoverStreamsWithClient(unittest.TestCase):
+    """Tests for discover_streams() when a client is supplied."""
+
+    @patch("tap_invoiced.discover._check_stream_access")
+    def test_all_accessible_all_in_catalog(self, mock_check):
+        """All streams accessible → all six appear in the catalog."""
+        mock_check.return_value = True
+        client = MagicMock()
+        result = discover_streams(client)
+        stream_ids = {s["tap_stream_id"] for s in result["streams"]}
+        self.assertEqual(EXPECTED_STREAMS, stream_ids)
+
+    @patch("tap_invoiced.discover._check_stream_access")
+    def test_inaccessible_stream_excluded(self, mock_check):
+        """A stream returning False from access check is excluded from the catalog."""
+        blocked = "invoices"
+        mock_check.side_effect = lambda client, name: name != blocked
+        client = MagicMock()
+        result = discover_streams(client)
+        stream_ids = {s["tap_stream_id"] for s in result["streams"]}
+        self.assertNotIn(blocked, stream_ids)
+        self.assertEqual(EXPECTED_STREAMS - {blocked}, stream_ids)
+
+    @patch("tap_invoiced.discover._check_stream_access")
+    def test_all_inaccessible_returns_empty_catalog(self, mock_check):
+        """All streams inaccessible → empty streams list."""
+        mock_check.return_value = False
+        client = MagicMock()
+        result = discover_streams(client)
+        self.assertEqual([], result["streams"])
+
+    @patch("tap_invoiced.discover._check_stream_access")
+    def test_check_called_once_per_stream(self, mock_check):
+        """_check_stream_access is called exactly once per stream."""
+        mock_check.return_value = True
+        client = MagicMock()
+        discover_streams(client)
+        self.assertEqual(len(EXPECTED_STREAMS), mock_check.call_count)
+
+    def test_no_client_skips_access_check(self):
+        """discover_streams(None) skips access checks and returns all streams."""
+        result = discover_streams(None)
+        stream_ids = {s["tap_stream_id"] for s in result["streams"]}
+        self.assertEqual(EXPECTED_STREAMS, stream_ids)
+
+    def test_no_client_default_arg_skips_access_check(self):
+        """discover_streams() with no argument skips access checks."""
+        result = discover_streams()
+        stream_ids = {s["tap_stream_id"] for s in result["streams"]}
+        self.assertEqual(EXPECTED_STREAMS, stream_ids)
 
 
 if __name__ == "__main__":

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -4,7 +4,7 @@ Covers: discover_streams(), load_schemas(), get_metadata(), field inclusion rule
 and stream access-checking logic (check_stream_access / _check_stream_access).
 """
 import unittest
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock
 
 from singer import metadata
 from invoiced.errors import ApiError
@@ -15,8 +15,8 @@ from tap_invoiced.discover import (
     get_metadata,
     _check_stream_access,
     _InvoicedAuthError,
-    STREAM_SDK_OBJECTS,
 )
+from tap_invoiced.constants import STREAM_SDK_OBJECTS
 from tap_invoiced.stream_access import check_stream_access
 
 EXPECTED_STREAMS = {
@@ -250,7 +250,7 @@ class TestGetMetadata(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestCheckStreamAccessHelper(unittest.TestCase):
-    """Tests for the reusable check_stream_access helper in tap_invoiced.utils."""
+    """Tests for the reusable check_stream_access helper in tap_invoiced.stream_access."""
 
     def test_returns_true_when_probe_succeeds(self):
         result = check_stream_access("invoices", probe_fn=lambda: None, auth_error_types=_InvoicedAuthError)


### PR DESCRIPTION
# Description of change

This PR updates discovery to probe each Invoiced stream endpoint and exclude streams that the provided credentials cannot access (HTTP 401/403), so generated Singer catalogs only contain authorized streams.

**Changes:**
- Added `tap_invoiced/stream_access.py` — a focused `check_stream_access(client, stream_name)` helper that probes a stream via a minimal `list(per_page=1, page=1)` call and returns True/False on 401/403
- Added `tap_invoiced/constants.py` — single source of truth for the stream to SDK object mapping
- Updated `discover_streams()` to accept an optional `client`; when provided, it calls `check_stream_access` per stream, logs a warning for excluded streams, and raises `InvoicedForbiddenError` if no streams are accessible
- Updated __init__.py — builds an `invoiced.Client` during `--discover` and passes it to `discover_streams()`; also normalizes `sandbox` config to accept both boolean true and string "true"
- Added unit tests covering the access-check helper, catalog filtering, partial exclusion, and all-streams-blocked error case

Jira: [SAC-30974](https://qlik-dev.atlassian.net/browse/SAC-30974)

# Manual QA steps
- [x] Discovery: `tap-invoiced --config config.json --discover` — verify catalog contains only accessible streams
- [x] Discovery with blocked credentials — verify `InvoicedForbiddenError` is raised when no streams are accessible
- [x] Sync: `tap-invoiced --config config.json --catalog catalog.json --state state.json` — verify sync runs normally
- [x] Unit Tests: `coverage run -m pytest tests/unittests` — all tests pass
- [x] Integration test: running
 
# Risks
- Discovery now makes one extra API call per stream; adds ~6 lightweight requests during `--discover`
- Taps with fully restricted credentials will now fail fast at discovery instead of silently at sync time (intentional)
 
# Rollback steps
 - Revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
